### PR TITLE
Fix invalid 'date' search parameter in FHIR Condition search

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,3 +529,4 @@ Thanks to everyone who contributed to this project:
 - [KutSaleh](https://github.com/KutSaleh)
 - [weberch-ukl](https://github.com/weberch-ukl)
 - [mw-uke](https://github.com/mw-uke)
+- [FloSchramm](https://github.com/FloSchramm)

--- a/src/main/java/de/ukbonn/mwtek/dashboard/misc/FhirServerQuerySuffixBuilder.java
+++ b/src/main/java/de/ukbonn/mwtek/dashboard/misc/FhirServerQuerySuffixBuilder.java
@@ -44,7 +44,8 @@ public class FhirServerQuerySuffixBuilder implements QuerySuffixBuilder {
   private static final String COUNT_EQUALS = "&_count=";
   private static final String DELIMITER = ",";
   public static final String SUMMARY_COUNT = "&_summary=count";
-  public static final String DATE_GE = "&date=ge";
+  public static final String OBSERVATION_DATE_GE = "&date=ge";
+  public static final String CONDITION_DATE_GE = "&recorded-date=ge";
   public static final String CODE_PARAM = "code=";
   public static final String PRETTY_FALSE_PARAM = "&_pretty=false";
   // public static final String CLASS_IMP = "&class=IMP";
@@ -86,7 +87,7 @@ public class FhirServerQuerySuffixBuilder implements QuerySuffixBuilder {
 
         // Append the starting date filter for COVID observations
         if (dataRetrievalService.getFilterResourcesByDate())
-          suffixBuilder.append(DATE_GE).append(getStartingDate(COVID));
+          suffixBuilder.append(OBSERVATION_DATE_GE).append(getStartingDate(COVID));
       }
       case INFLUENZA -> {
         // Join Influenza PCR codes
@@ -97,7 +98,7 @@ public class FhirServerQuerySuffixBuilder implements QuerySuffixBuilder {
 
         // Append the starting date filter for Influenza observations
         if (dataRetrievalService.getFilterResourcesByDate())
-          suffixBuilder.append(DATE_GE).append(getStartingDate(INFLUENZA));
+          suffixBuilder.append(OBSERVATION_DATE_GE).append(getStartingDate(INFLUENZA));
       }
     }
     // Append additional fixed parameters
@@ -131,7 +132,7 @@ public class FhirServerQuerySuffixBuilder implements QuerySuffixBuilder {
 
         // Append the starting date filter for COVID conditions
         if (dataRetrievalService.getFilterResourcesByDate())
-          suffixBuilder.append(DATE_GE).append(getStartingDate(COVID));
+          suffixBuilder.append(CONDITION_DATE_GE).append(getStartingDate(COVID));
       }
       case INFLUENZA -> {
         // Join Influenza ICD codes
@@ -140,7 +141,7 @@ public class FhirServerQuerySuffixBuilder implements QuerySuffixBuilder {
 
         // Append the starting date filter for Influenza conditions
         if (dataRetrievalService.getFilterResourcesByDate())
-          suffixBuilder.append(DATE_GE).append(getStartingDate(INFLUENZA));
+          suffixBuilder.append(CONDITION_DATE_GE).append(getStartingDate(INFLUENZA));
       }
       case KIDS_RADAR -> {
         // Join KidsRadar ICD codes
@@ -262,13 +263,13 @@ public class FhirServerQuerySuffixBuilder implements QuerySuffixBuilder {
     if (dataRetrievalService.getFilterResourcesByDate()) {
       switch (dataItemContext) {
         case COVID ->
-            suffixBuilder.append(DATE_GE).append(getStartingDate(COVID)).append(MIDNIGHT_TS);
+            suffixBuilder.append(OBSERVATION_DATE_GE).append(getStartingDate(COVID)).append(MIDNIGHT_TS);
         case INFLUENZA ->
-            suffixBuilder.append(DATE_GE).append(getStartingDate(INFLUENZA)).append(MIDNIGHT_TS);
+            suffixBuilder.append(OBSERVATION_DATE_GE).append(getStartingDate(INFLUENZA)).append(MIDNIGHT_TS);
         case KIDS_RADAR ->
-            suffixBuilder.append(DATE_GE).append(getStartingDate(KIDS_RADAR)).append(MIDNIGHT_TS);
+            suffixBuilder.append(OBSERVATION_DATE_GE).append(getStartingDate(KIDS_RADAR)).append(MIDNIGHT_TS);
         case ACRIBIS ->
-            suffixBuilder.append(DATE_GE).append(individualDateString).append(MIDNIGHT_TS);
+            suffixBuilder.append(OBSERVATION_DATE_GE).append(individualDateString).append(MIDNIGHT_TS);
       }
     }
     // Filtering of case class will be done in post-processing since it's way faster
@@ -406,7 +407,7 @@ public class FhirServerQuerySuffixBuilder implements QuerySuffixBuilder {
         + CONSENT_CATEGORY_SYSTEM
         + PIPE
         + CONSENT_CATEGORY_CODE
-        + DATE_GE
+        + OBSERVATION_DATE_GE
         + getStartingDate(ACRIBIS);
   }
 

--- a/src/test/java/de/ukbonn/mwtek/dashboard/misc/FhirServerQuerySuffixBuilderTest.java
+++ b/src/test/java/de/ukbonn/mwtek/dashboard/misc/FhirServerQuerySuffixBuilderTest.java
@@ -1,0 +1,76 @@
+package de.ukbonn.mwtek.dashboard.misc;
+
+import de.ukbonn.mwtek.dashboard.services.FhirDataRetrievalService;
+import de.ukbonn.mwtek.dashboardlogic.enums.DataItemContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class FhirServerQuerySuffixBuilderTest {
+
+    @InjectMocks
+    private FhirServerQuerySuffixBuilder suffixBuilder;
+
+    @Test
+    void buildCovidObservationQuery() {
+        final FhirDataRetrievalService fhirDataRetrieval = mock(FhirDataRetrievalService.class);
+        doReturn(List.of("94640-0", "94306-8", "96763-8")).when(fhirDataRetrieval).getCovidLabPcrCodes();
+        doReturn(List.of("96741-4", "96895-8")).when(fhirDataRetrieval).getCovidLabVariantCodes();
+        doReturn(true).when(fhirDataRetrieval).getFilterResourcesByDate();
+
+        final String observations = suffixBuilder.getObservations(fhirDataRetrieval, 1, true, DataItemContext.COVID);
+
+        Assertions.assertThat(observations).isEqualTo("Observation?code=94640-0,94306-8,96763-8,96741-4,96895-8&date=ge2020-01-27&_pretty=false&_count=0&_summary=count");
+    }
+
+    @Test
+    void buildInfluenzaObservationQuery() {
+        final FhirDataRetrievalService fhirDataRetrieval = mock(FhirDataRetrievalService.class);
+        doReturn(List.of("J10.0", "J10.1", "J10.8", "J09")).when(fhirDataRetrieval).getInfluenzaLabPcrCodes();
+        doReturn(true).when(fhirDataRetrieval).getFilterResourcesByDate();
+
+        final String observations = suffixBuilder.getObservations(fhirDataRetrieval, 1, true, DataItemContext.INFLUENZA);
+
+        Assertions.assertThat(observations).isEqualTo("Observation?code=J10.0,J10.1,J10.8,J09&date=ge2022-09-01&_pretty=false&_count=0&_summary=count");
+    }
+
+    @Test
+    void buildCovidConditionQuery() {
+        final FhirDataRetrievalService fhirDataRetrieval = mock(FhirDataRetrievalService.class);
+        doReturn(List.of("U07.1")).when(fhirDataRetrieval).getCovidIcdCodes();
+        doReturn(true).when(fhirDataRetrieval).getFilterResourcesByDate();
+
+        final String observations = suffixBuilder.getConditions(fhirDataRetrieval, 1, true, DataItemContext.COVID);
+
+        Assertions.assertThat(observations).isEqualTo("Condition?code=U07.1&recorded-date=ge2020-01-27&_pretty=false&_count=0&_summary=count");
+    }
+
+    @Test
+    void buildInfluenzaConditionQuery() {
+        final FhirDataRetrievalService fhirDataRetrieval = mock(FhirDataRetrievalService.class);
+        doReturn(List.of("J10.0", "J10.1", "J10.8", "J09")).when(fhirDataRetrieval).getInfluenzaIcdCodes();
+        doReturn(true).when(fhirDataRetrieval).getFilterResourcesByDate();
+
+        final String observations = suffixBuilder.getConditions(fhirDataRetrieval, 1, true, DataItemContext.INFLUENZA);
+
+        Assertions.assertThat(observations).isEqualTo("Condition?code=J10.0,J10.1,J10.8,J09&recorded-date=ge2022-09-01&_pretty=false&_count=0&_summary=count");
+    }
+
+    @Test
+    void buildKidsRadarConditionQuery() {
+        final FhirDataRetrievalService fhirDataRetrieval = mock(FhirDataRetrievalService.class);
+        doReturn(List.of("F43.0", "F43.1", "F43.2", "...")).when(fhirDataRetrieval).getKidsRadarIcdCodesAll();
+
+        final String observations = suffixBuilder.getConditions(fhirDataRetrieval, 1, true, DataItemContext.KIDS_RADAR);
+
+        Assertions.assertThat(observations).isEqualTo("Condition?code=F43.0,F43.1,F43.2,...&_pretty=false&_count=0&_summary=count");
+    }
+}


### PR DESCRIPTION
Hello,

I opened this MR to fix a bug in the `FhirServerQuerySuffixBuilder` when `Condition` resources are queried via FHIR search.

The current implementation uses `date` as a search parameter for `Condition` queries. However, according to the FHIR R4 specification, `date` is not a valid search parameter for the `Condition` resource. 

I have replaced the invalid `date` parameter with the standard-compliant `recorded-date` parameter to fix the issue.